### PR TITLE
Corrects token name.

### DIFF
--- a/packages/docs/src/pages/core-concepts/ideas.js
+++ b/packages/docs/src/pages/core-concepts/ideas.js
@@ -105,7 +105,7 @@ const Documentation = () => {
             $brand-background-dark: #195594;
             
             /** sizes.scss */
-            $sizes-5: 40px;
+            $size-5: 40px;
           `}</Example.Code>
           <Example.Code
             lang="scss"


### PR DESCRIPTION
The token name declared in the example is `sizes-5`, however when using the token name in the same example, the token name is written as `size-5` ( `s`) omitted. This PR fixes that error by changing the name of the declared token to `size-5`.