### PR TITLE
Fix walk for case where obj is null

### DIFF
--- a/packages/ds-tools/primitives/element.js
+++ b/packages/ds-tools/primitives/element.js
@@ -132,7 +132,7 @@ function mergeAll(a = {}, b = {}, c = {}) {
 }
 
 function walk(obj, callback) {
-  if (typeof obj === 'object') {
+  if (obj && typeof obj === 'object') {
     callback(obj)
     Object.values(obj).map(node => walk(node, callback))
   }


### PR DESCRIPTION
Since `typeof null === 'object'`, the test used for walking object trees will incorrectly (I assume that this is not intended?) fire `callback` on `null` or properties of objects whose value is `null`.