### PR TITLE
grid align example preview with code

### DIFF
--- a/packages/docs/src/pages/components/grid.js
+++ b/packages/docs/src/pages/components/grid.js
@@ -202,13 +202,13 @@ const Documentation = () => {
                 span={[12, 6, 5]}
                 css={{ height: 140, background: '#A8EEC1' }}
               >
-                column
+                half &
               </Column>
               <Column
                 span={[12, 6, 5]}
                 css={{ height: 140, background: '#B7DBF7' }}
               >
-                column
+                half
               </Column>
             </Grid>
           </Example.Preview>


### PR DESCRIPTION
It's a tiny detail but I guess it's probably better to align the text of the columns from the preview with the code.

<img width="674" alt="Screenshot 2020-03-29 at 22 58 48" src="https://user-images.githubusercontent.com/5595092/77860722-ee395780-7210-11ea-80ad-6cf379811ba2.png">
