### PR TITLE
add forwardRef to all components

### DIFF
--- a/packages/ecosystem/stats/index.js
+++ b/packages/ecosystem/stats/index.js
@@ -2,15 +2,29 @@ import React from 'react'
 import { Stack, Text } from 'react-ui'
 import styles from './styles'
 
-const Stats = (props) => (
-  <Stack direction="vertical" gap={1} component="Stats" {...props} />
-)
+const Stats = React.forwardRef(function Stack(props, ref) {
+  return (
+    <Stack
+      ref={ref}
+      direction="vertical"
+      gap={1}
+      component="Stats"
+      {...props}
+    />
+  )
+})
 
-const Label = (props) => <Text component="StatsLabel" {...props} />
+const Label = React.forwardRef((props, ref) => (
+  <Text ref={ref} component="StatsLabel" {...props} />
+))
 
-const Value = (props) => <Text component="StatsValue" {...props} />
+const Value = React.forwardRef((props, ref) => (
+  <Text ref={ref} component="StatsValue" {...props} />
+))
 
-const Description = (props) => <Text component="StatsDescription" {...props} />
+const Description = React.forwardRef((props, ref) => (
+  <Text ref={ref} component="StatsDescription" {...props} />
+))
 
 Stats.Label = Label
 Stats.Value = Value

--- a/packages/ecosystem/stats/index.js
+++ b/packages/ecosystem/stats/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Stack, Text } from 'react-ui'
 import styles from './styles'
 
-const Stats = React.forwardRef(function Stack(props, ref) {
+const Stats = React.forwardRef(function Stats(props, ref) {
   return (
     <Stack
       ref={ref}
@@ -18,13 +18,19 @@ const Label = React.forwardRef((props, ref) => (
   <Text ref={ref} component="StatsLabel" {...props} />
 ))
 
+Label.displayName = 'Stats.Label'
+
 const Value = React.forwardRef((props, ref) => (
   <Text ref={ref} component="StatsValue" {...props} />
 ))
 
+Value.displayName = 'Stats.Value'
+
 const Description = React.forwardRef((props, ref) => (
   <Text ref={ref} component="StatsDescription" {...props} />
 ))
+
+Description.displayName = 'Stats.Description'
 
 Stats.Label = Label
 Stats.Value = Value

--- a/packages/react-ui/src/components/avatar/index.js
+++ b/packages/react-ui/src/components/avatar/index.js
@@ -4,14 +4,17 @@ import { Element } from '../../primitives'
 import { styles } from './avatar.styles'
 import { merge } from '../../utils'
 
-export const Avatar = ({ css, ...props }) => (
-  <Element
-    as="img"
-    component="Avatar"
-    css={merge(styles.Avatar, css)}
-    {...props}
-  />
-)
+export const Avatar = React.forwardRef(function Avatar({ css, ...props }, ref) {
+  return (
+    <Element
+      ref={ref}
+      as="img"
+      component="Avatar"
+      css={merge(styles.Avatar, css)}
+      {...props}
+    />
+  )
+})
 
 Avatar.propTypes = {
   /** Image url for avatar */

--- a/packages/react-ui/src/components/breadcrumb/index.js
+++ b/packages/react-ui/src/components/breadcrumb/index.js
@@ -15,12 +15,16 @@ const Separator = props => (
   </Element>
 )
 
-export const Breadcrumb = ({ separator, css, ...props }) => {
+export const Breadcrumb = React.forwardRef(function Breadcrumb(
+  { separator, css, ...props },
+  ref
+) {
   const children = React.Children.map(props.children, function(child, index) {
     const isLast = index === props.children.length - 1
 
     return (
       <Element
+        ref={ref}
         as="li"
         component="BreadcrumbItem"
         css={styles.BreadcrumbItem}
@@ -43,7 +47,7 @@ export const Breadcrumb = ({ separator, css, ...props }) => {
       <ol>{children}</ol>
     </Element>
   )
-}
+})
 
 Breadcrumb.propTypes = {
   separator: PropTypes.node

--- a/packages/react-ui/src/components/button/index.js
+++ b/packages/react-ui/src/components/button/index.js
@@ -5,16 +5,17 @@ import { styles } from './button.styles'
 import { merge } from '../../utils'
 
 /** Description of a button */
-const Button = ({ size, css, ...props }) => {
+const Button = React.forwardRef(function Button({ size, css, ...props }, ref) {
   return (
     <Element
+      ref={ref}
       as="button"
       component="Button"
       css={merge(styles.Button, { height: 'Button.' + size }, css)}
       {...props}
     />
   )
-}
+})
 
 Button.propTypes = {
   /** Description of an button prop */

--- a/packages/react-ui/src/components/card/index.js
+++ b/packages/react-ui/src/components/card/index.js
@@ -3,15 +3,16 @@ import { Element } from '../../primitives'
 import { styles } from './card.styles'
 import { merge } from '../../utils'
 
-function Card({ css, ...props }) {
+const Card = React.forwardRef(function Card({ css, ...props }, ref) {
   return (
     <Element
+      ref={ref}
       as="div"
       component="Card"
       css={merge(styles.Card, css)}
       {...props}
     />
   )
-}
+})
 
 export { Card }

--- a/packages/react-ui/src/components/form/index.js
+++ b/packages/react-ui/src/components/form/index.js
@@ -7,9 +7,10 @@ import { Element } from '../../primitives'
 import { Stack } from '../stack'
 import { merge } from '../../utils'
 
-const Form = ({ css, ...props }) => {
+const Form = React.forwardRef(function Form({ css, ...props }, ref) {
   return (
     <Element
+      ref={ref}
       as="form"
       component="Form"
       css={merge(styles.Form, css)}
@@ -20,21 +21,23 @@ const Form = ({ css, ...props }) => {
       </Stack>
     </Element>
   )
-}
+})
 
 Form.propTypes = {}
 
-Form.Header = ({ css, ...props }) => (
+Form.defaultProps = {}
+
+Form.Header = React.forwardRef(({ css, ...props }, ref) => (
   <Element
+    ref={ref}
     as="h1"
     component="FormHeader"
     css={merge(styles.FormHeader, css)}
     {...props}
   />
-)
+))
 
 Form.Header.propTypes = {
-  /** Description of an button prop */
   as: PropTypes.string
 }
 
@@ -42,16 +45,18 @@ Form.Header.defaultProps = {
   as: 'h1'
 }
 
-Form.Label = ({ css, ...props }) => (
+Form.Label = React.forwardRef(({ css, ...props }, ref) => (
   <Element
+    ref={ref}
     as="label"
     component="FormLabel"
     css={merge(styles.FormLabel, css)}
     {...props}
   />
-)
+))
 
-const FormField = function({ label, id, isRequired, css, ...props }) {
+// attach child components to Form
+Form.Field = React.forwardRef(({ label, id, isRequired, css, ...props }) => {
   const inputId = useId(id)
 
   const children = React.Children.map(props.children, (child, index) => {
@@ -83,9 +88,9 @@ const FormField = function({ label, id, isRequired, css, ...props }) {
       {children}
     </Element>
   )
-}
+})
 
-FormField.propTypes = {
+Form.Field.propTypes = {
   /** first */
   label: PropTypes.string.isRequired,
   /** second */
@@ -93,15 +98,5 @@ FormField.propTypes = {
   /** third */
   isRequired: PropTypes.bool
 }
-
-// attach display name explicitly to make codegen work
-FormField.displayName = 'Form.Field'
-
-Form.propTypes = {}
-
-Form.defaultProps = {}
-
-// attach child components to Form
-Form.Field = FormField
 
 export { Form }

--- a/packages/react-ui/src/components/form/index.js
+++ b/packages/react-ui/src/components/form/index.js
@@ -37,6 +37,8 @@ Form.Header = React.forwardRef(({ css, ...props }, ref) => (
   />
 ))
 
+Form.Header.displayName = 'Form.Header'
+
 Form.Header.propTypes = {
   as: PropTypes.string
 }
@@ -54,6 +56,8 @@ Form.Label = React.forwardRef(({ css, ...props }, ref) => (
     {...props}
   />
 ))
+
+Form.Label.displayName = 'Form.Label'
 
 // attach child components to Form
 Form.Field = React.forwardRef(({ label, id, isRequired, css, ...props }) => {
@@ -89,6 +93,8 @@ Form.Field = React.forwardRef(({ label, id, isRequired, css, ...props }) => {
     </Element>
   )
 })
+
+Form.Field.displayName = 'Form.Field'
 
 Form.Field.propTypes = {
   /** first */

--- a/packages/react-ui/src/components/form/index.js
+++ b/packages/react-ui/src/components/form/index.js
@@ -60,39 +60,41 @@ Form.Label = React.forwardRef(({ css, ...props }, ref) => (
 Form.Label.displayName = 'Form.Label'
 
 // attach child components to Form
-Form.Field = React.forwardRef(({ label, id, isRequired, css, ...props }) => {
-  const inputId = useId(id)
+Form.Field = React.forwardRef(
+  ({ label, id, isRequired, css, ...props }, ref) => {
+    const inputId = useId(id)
 
-  const children = React.Children.map(props.children, (child, index) => {
-    const additionalProps = {}
+    const children = React.Children.map(props.children, (child, index) => {
+      const additionalProps = {}
 
-    // We only attach id to the first child.
-    // This is irrelevant when there is only one form element.
-    // When there are multiple elements in the same field, the first one gets focused.
-    if (index === 0) additionalProps.id = inputId
+      // We only attach id to the first child.
+      // This is irrelevant when there is only one form element.
+      // When there are multiple elements in the same field, the first one gets focused.
+      if (index === 0) additionalProps.id = inputId
 
-    // this one is tricky. We don't really know the intention here if the user
-    // wanted to make both fields required or just one of them
-    // we assume it's both
-    additionalProps.required = isRequired
+      // this one is tricky. We don't really know the intention here if the user
+      // wanted to make both fields required or just one of them
+      // we assume it's both
+      additionalProps.required = isRequired
 
-    return React.cloneElement(child, { ...additionalProps })
-  })
+      return React.cloneElement(child, { ...additionalProps, ref })
+    })
 
-  return (
-    <Element
-      as="fieldset"
-      component="FormField"
-      css={merge(styles.FormField, css)}
-      {...props}
-    >
-      <Form.Label htmlFor={inputId}>
-        {label} {isRequired ? <span>*</span> : null}
-      </Form.Label>
-      {children}
-    </Element>
-  )
-})
+    return (
+      <Element
+        as="fieldset"
+        component="FormField"
+        css={merge(styles.FormField, css)}
+        {...props}
+      >
+        <Form.Label htmlFor={inputId}>
+          {label} {isRequired ? <span>*</span> : null}
+        </Form.Label>
+        {children}
+      </Element>
+    )
+  }
+)
 
 Form.Field.displayName = 'Form.Field'
 

--- a/packages/react-ui/src/components/grid/index.js
+++ b/packages/react-ui/src/components/grid/index.js
@@ -4,7 +4,10 @@ import { Element } from '../../primitives'
 import { styles } from './grid.styles'
 import { merge } from '../../utils'
 
-function Grid({ gap, columnGap, rowGap, css, ...props }) {
+const Grid = React.forwardRef(function Grid(
+  { gap, columnGap, rowGap, css, ...props },
+  ref
+) {
   let gaps = {}
 
   if (gap === 'auto') {
@@ -19,15 +22,19 @@ function Grid({ gap, columnGap, rowGap, css, ...props }) {
 
   return (
     <Element
+      ref={ref}
       as="div"
       component="Grid"
       css={merge(styles.Grid, gaps, css)}
       {...props}
     />
   )
-}
+})
 
-function Column({ start, end, span, css, ...props }) {
+const Column = React.forwardRef(function Column(
+  { start, end, span, css, ...props },
+  ref
+) {
   let column = {}
 
   if (Array.isArray(start)) column.gridColumnStart = start.map(s => s)
@@ -46,17 +53,18 @@ function Column({ start, end, span, css, ...props }) {
 
   return (
     <Element
+      ref={ref}
       as="div"
       css={merge(column, css)}
       component="GridColumn"
       {...props}
     />
   )
-}
+})
 
-function Row(props) {
-  return <Column span={12} as={Grid} component="GridRow" {...props} />
-}
+const Row = React.forwardRef(function Row(props, ref) {
+  return <Column ref={ref} span={12} as={Grid} component="GridRow" {...props} />
+})
 
 Grid.propTypes = {
   gap: PropTypes.oneOf(['auto', 'none']),

--- a/packages/react-ui/src/components/heading/index.js
+++ b/packages/react-ui/src/components/heading/index.js
@@ -6,9 +6,13 @@ import { styles } from './heading.styles'
 import { merge } from '../../utils'
 
 /** Description of an input */
-function Heading({ size, css, ...props }) {
+const Heading = React.forwardRef(function Heading(
+  { size, css, ...props },
+  ref
+) {
   return (
     <Element
+      ref={ref}
       as="h1"
       component="Heading"
       css={merge(
@@ -19,7 +23,7 @@ function Heading({ size, css, ...props }) {
       {...props}
     />
   )
-}
+})
 
 const getWithFallback = (value, fallback) => theme => {
   const valueIfDefined = delve(theme, value)

--- a/packages/react-ui/src/components/image/index.js
+++ b/packages/react-ui/src/components/image/index.js
@@ -3,15 +3,19 @@ import { Element } from '../../primitives'
 import { styles } from './image.styles'
 import { merge } from '../../utils'
 
-function Image({ width, height, css, ...props }) {
+const Image = React.forwardRef(function Image(
+  { width, height, css, ...props },
+  ref
+) {
   return (
     <Element
+      ref={ref}
       as="img"
       css={merge(styles.Image, { width, height }, css)}
       component="Image"
       {...props}
     />
   )
-}
+})
 
 export { Image }

--- a/packages/react-ui/src/components/input/index.js
+++ b/packages/react-ui/src/components/input/index.js
@@ -5,19 +5,18 @@ import { styles } from './input.styles'
 import { merge } from '../../utils'
 
 /** Description of an input */
-function Input({ invalid, css, ...props }) {
+const Input = React.forwardRef(function Input({ invalid, css, ...props }, ref) {
   return (
-    <>
-      <Element
-        as="input"
-        component="Input"
-        aria-invalid={invalid}
-        css={merge(styles.Input, css)}
-        {...props}
-      />
-    </>
+    <Element
+      ref={ref}
+      as="input"
+      component="Input"
+      aria-invalid={invalid}
+      css={merge(styles.Input, css)}
+      {...props}
+    />
   )
-}
+})
 
 Input.propTypes = {
   /** Description of an input prop */

--- a/packages/react-ui/src/components/link/index.js
+++ b/packages/react-ui/src/components/link/index.js
@@ -4,11 +4,17 @@ import { styles } from './link.styles'
 import { Text } from '../text'
 import { merge } from '../../utils'
 
-export const Link = ({ css, ...props }) => {
+export const Link = React.forwardRef(function Link({ css, ...props }, ref) {
   return (
-    <Text as="a" component="Link" css={merge(styles.Link, css)} {...props} />
+    <Text
+      ref={ref}
+      as="a"
+      component="Link"
+      css={merge(styles.Link, css)}
+      {...props}
+    />
   )
-}
+})
 
 Link.propTypes = {}
 

--- a/packages/react-ui/src/components/menu/index.js
+++ b/packages/react-ui/src/components/menu/index.js
@@ -20,6 +20,8 @@ const MenuButton = React.forwardRef((props, ref) => {
   )
 })
 
+MenuButton.displayName = 'Menu.Button'
+
 const MenuList = React.forwardRef(({ css, ...props }, ref) => {
   return (
     <Element
@@ -32,6 +34,8 @@ const MenuList = React.forwardRef(({ css, ...props }, ref) => {
   )
 })
 
+MenuList.displayName = 'Menu.List'
+
 const MenuItem = React.forwardRef(({ css, ...props }, ref) => {
   return (
     <Element
@@ -43,6 +47,8 @@ const MenuItem = React.forwardRef(({ css, ...props }, ref) => {
     />
   )
 })
+
+MenuItem.displayName = 'Menu.Item'
 
 Menu.Button = MenuButton
 Menu.List = MenuList

--- a/packages/react-ui/src/components/menu/index.js
+++ b/packages/react-ui/src/components/menu/index.js
@@ -5,41 +5,44 @@ import { styles } from './menu.styles'
 import { Button } from '../button'
 import { merge } from '../../utils'
 
-const Menu = ({ ...props }) => {
+const Menu = React.forwardRef(function Menu(props, ref) {
+  return <Element ref={ref} as={ReachMenu.Menu} {...props} />
+})
+
+const MenuButton = React.forwardRef((props, ref) => {
   return (
-    <Element as={ReachMenu.Menu} {...props}>
-      {props.children}
-    </Element>
+    <Button
+      ref={ref}
+      variant="secondary"
+      as={ReachMenu.MenuButton}
+      {...props}
+    />
   )
-}
+})
 
-const MenuButton = props => {
-  return <Button variant="secondary" as={ReachMenu.MenuButton} {...props} />
-}
-
-const MenuList = ({ css, ...props }) => {
+const MenuList = React.forwardRef(({ css, ...props }, ref) => {
   return (
     <Element
+      ref={ref}
       as={ReachMenu.MenuList}
       component="MenuList"
       css={merge(styles.MenuList, css)}
       {...props}
-    >
-      {props.children}
-    </Element>
+    />
   )
-}
+})
 
-const MenuItem = ({ css, ...props }) => {
+const MenuItem = React.forwardRef(({ css, ...props }, ref) => {
   return (
     <Element
+      ref={ref}
       as={ReachMenu.MenuItem}
       component="MenuItem"
       css={merge(styles.MenuItem, css)}
       {...props}
     />
   )
-}
+})
 
 Menu.Button = MenuButton
 Menu.List = MenuList

--- a/packages/react-ui/src/components/paragraph/index.js
+++ b/packages/react-ui/src/components/paragraph/index.js
@@ -4,9 +4,13 @@ import { Stack } from '../stack'
 import { styles } from './paragraph.styles'
 import { merge } from '../../utils'
 
-function Paragraph({ css, gap, ...props }) {
+const Paragraph = React.forwardRef(function Paragraph(
+  { css, gap, ...props },
+  ref
+) {
   return (
     <Stack
+      ref={ref}
       as="p"
       component="Paragraph"
       gap={gap}
@@ -15,7 +19,7 @@ function Paragraph({ css, gap, ...props }) {
       {...props}
     />
   )
-}
+})
 
 Paragraph.propTypes = {
   gap: PropTypes.oneOfType([

--- a/packages/react-ui/src/components/select/index.js
+++ b/packages/react-ui/src/components/select/index.js
@@ -22,11 +22,12 @@ const usePlaceholder = props => {
   return { placeholderStyles, onChange }
 }
 
-function Select({ css, ...props }) {
+const Select = React.forwardRef(function Select({ css, ...props }, ref) {
   const { placeholderStyles, onChange } = usePlaceholder(props)
 
   return (
     <Input
+      ref={ref}
       as="select"
       component="Select"
       css={merge(merge(styles.Select, placeholderStyles), css)}
@@ -34,7 +35,7 @@ function Select({ css, ...props }) {
       onChange={mergeFns(onChange, props.onChange)}
     />
   )
-}
+})
 
 Select.propTypes = {}
 

--- a/packages/react-ui/src/components/spinner/index.js
+++ b/packages/react-ui/src/components/spinner/index.js
@@ -4,9 +4,13 @@ import { Element } from '../../primitives'
 import { styles } from './spinner.styles'
 import { merge } from '../../utils'
 
-export const Spinner = React.forwardRef(function Spinner({ css, ...props }) {
+export const Spinner = React.forwardRef(function Spinner(
+  { css, ...props },
+  ref
+) {
   return (
     <Element
+      ref={ref}
       as="span"
       component="Spinner"
       css={merge(styles.Spinner, css)}

--- a/packages/react-ui/src/components/spinner/index.js
+++ b/packages/react-ui/src/components/spinner/index.js
@@ -4,14 +4,16 @@ import { Element } from '../../primitives'
 import { styles } from './spinner.styles'
 import { merge } from '../../utils'
 
-export const Spinner = ({ css, ...props }) => (
-  <Element
-    as="span"
-    component="Spinner"
-    css={merge(styles.Spinner, css)}
-    {...props}
-  />
-)
+export const Spinner = React.forwardRef(function Spinner({ css, ...props }) {
+  return (
+    <Element
+      as="span"
+      component="Spinner"
+      css={merge(styles.Spinner, css)}
+      {...props}
+    />
+  )
+})
 
 Spinner.propTypes = {}
 

--- a/packages/react-ui/src/components/stack/index.js
+++ b/packages/react-ui/src/components/stack/index.js
@@ -20,7 +20,10 @@ const createGap = (direction, gap) => {
   }
 }
 
-const Stack = ({ inline, justify, align, direction, gap, css, ...props }) => {
+const Stack = React.forwardRef(function Stack(
+  { inline, justify, align, direction, gap, css, ...props },
+  ref
+) {
   const styles = {
     display: inline ? 'inline-flex' : 'flex',
     // width: '100%', // causes weirdness in nested avatar. todo: debug
@@ -39,15 +42,15 @@ const Stack = ({ inline, justify, align, direction, gap, css, ...props }) => {
   }
 
   return (
-    <Element as="div" component="Stack" css={merge(styles, css)} {...props}>
-      {props.children}
-    </Element>
+    <Element
+      ref={ref}
+      as="div"
+      component="Stack"
+      css={merge(styles, css)}
+      {...props}
+    />
   )
-}
-
-const responsive = value => {
-  return { key: value }
-}
+})
 
 Stack.propTypes = {
   /** Description of the gap prop */

--- a/packages/react-ui/src/components/switch/index.js
+++ b/packages/react-ui/src/components/switch/index.js
@@ -4,7 +4,7 @@ import { Element } from '../../primitives'
 import { styles } from './switch.styles'
 import { merge } from '../../utils'
 
-const Switch = ({ css, ...props }) => {
+const Switch = React.forwardRef(function Switch({ css, ...props }, ref) {
   return (
     <Element
       as="label"
@@ -12,6 +12,7 @@ const Switch = ({ css, ...props }) => {
       component="SwitchContainer"
     >
       <Element
+        ref={ref}
         as="input"
         type="checkbox"
         css={styles.SwitchInput}
@@ -29,7 +30,7 @@ const Switch = ({ css, ...props }) => {
       </Element>
     </Element>
   )
-}
+})
 
 Switch.propTypes = {
   value: PropTypes.bool,

--- a/packages/react-ui/src/components/text/index.js
+++ b/packages/react-ui/src/components/text/index.js
@@ -3,9 +3,13 @@ import PropTypes from 'prop-types'
 import { Element } from '../../primitives'
 import { merge } from '../../utils'
 
-function Text({ size, color, align, weight, block, css, maxWidth, ...props }) {
+const Text = React.forwardRef(function Text(
+  { size, color, align, weight, block, css, maxWidth, ...props },
+  ref
+) {
   return (
     <Element
+      ref={ref}
       as="span"
       component="Text"
       css={merge(
@@ -23,7 +27,7 @@ function Text({ size, color, align, weight, block, css, maxWidth, ...props }) {
       {...props}
     />
   )
-}
+})
 
 const overflowStyles = {
   overflow: 'hidden',

--- a/packages/react-ui/src/components/textarea/index.js
+++ b/packages/react-ui/src/components/textarea/index.js
@@ -4,16 +4,17 @@ import { styles } from './textarea.styles'
 import { Input } from '../input'
 import { merge } from '../../utils'
 
-function Textarea({ css, ...props }) {
+const Textarea = React.forwardRef(function Textarea({ css, ...props }, ref) {
   return (
     <Input
+      ref={ref}
       as="textarea"
       css={merge(styles.Textarea, css)}
       component="Textarea"
       {...props}
     />
   )
-}
+})
 
 Textarea.propTypes = {
   rows: PropTypes.number


### PR DESCRIPTION
This PR adds `forwardRef` to all react-ui components (and ecosystem), I also took advantage of this PR and added a named function so in development the components show the name in the React Devtools.

Closes https://github.com/siddharthkp/react-ui/issues/29 and https://github.com/siddharthkp/react-ui/issues/34