### PR TITLE
Fix staging deployment with now

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^16.8.9",
     "react-scripts": "^3.4.0",
     "react-twitter-embed": "^3.0.3",
-    "react-ui": "1.0.0-beta.30",
+    "react-ui": "1.0.0-beta.24",
     "react-ui-stats": "0.0.1"
   },
   "author": "siddharthkp",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "react-scripts start",
+    "prebuild": "cd ../react-ui && yarn build",
     "build": "react-scripts build",
     "now-start": "serve -s build",
     "css": "theme.css"
@@ -20,7 +21,7 @@
     "react-dom": "^16.8.9",
     "react-scripts": "^3.4.0",
     "react-twitter-embed": "^3.0.3",
-    "react-ui": "1.0.0-beta.24",
+    "react-ui": "1.0.0-beta.30",
     "react-ui-stats": "0.0.1"
   },
   "author": "siddharthkp",

--- a/packages/docs/src/App.js
+++ b/packages/docs/src/App.js
@@ -14,7 +14,8 @@ import {
   Text,
   Menu,
   calc,
-  merge
+  merge,
+  version
 } from 'react-ui'
 
 import * as base from 'react-ui/themes/base'
@@ -70,19 +71,24 @@ const App = () => {
         >
           <MenuIcon />
         </Button>
-        <Menu>
-          <Menu.Button variant="link" style={{ paddingRight: 1 }}>
-            <Text marginRight={1} css={{ textTransform: 'capitalize' }}>
-              Theme: {theme}
-            </Text>
-            {chevron}
-          </Menu.Button>
-          <Menu.List>
-            <Menu.Item onSelect={_ => setTheme('base')}>Base</Menu.Item>
-            <Menu.Item onSelect={_ => setTheme('light')}>Light</Menu.Item>
-            <Menu.Item onSelect={_ => setTheme('dark')}>Dark</Menu.Item>
-          </Menu.List>
-        </Menu>
+        <div>
+          <Text variant="subtle" size={3}>
+            v{version}
+          </Text>
+          <Menu>
+            <Menu.Button variant="link" style={{ paddingRight: 1 }}>
+              <Text marginRight={1} css={{ textTransform: 'capitalize' }}>
+                Theme: {theme}
+              </Text>
+              {chevron}
+            </Menu.Button>
+            <Menu.List>
+              <Menu.Item onSelect={_ => setTheme('base')}>Base</Menu.Item>
+              <Menu.Item onSelect={_ => setTheme('light')}>Light</Menu.Item>
+              <Menu.Item onSelect={_ => setTheme('dark')}>Dark</Menu.Item>
+            </Menu.List>
+          </Menu>
+        </div>
       </Stack>
       <Grid
         css={{

--- a/packages/react-ui/index.js
+++ b/packages/react-ui/index.js
@@ -23,3 +23,6 @@ export * from './src/components/theme-provider'
 
 export { Element } from './src/primitives'
 export { merge, mergeFns, calc } from './src/utils'
+
+const version = '1.0.0-beta.30'
+export { version }

--- a/packages/react-ui/index.js
+++ b/packages/react-ui/index.js
@@ -1,3 +1,5 @@
+import { version } from './package.json'
+
 export * from './src/components/avatar'
 export * from './src/components/button'
 export * from './src/components/heading'
@@ -24,5 +26,4 @@ export * from './src/components/theme-provider'
 export { Element } from './src/primitives'
 export { merge, mergeFns, calc } from './src/utils'
 
-const version = '1.0.0-beta.30'
 export { version }

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ui",
-  "version": "1.0.0-beta.30",
+  "version": "1.0.0-beta.24",
   "description": "Customisable components and primitives based on design tokens",
   "homepage": "https://react-ui.dev",
   "source": "index.js",
@@ -36,6 +36,7 @@
     "rollup": "^1.27.8",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-peer-deps-external": "^2.2.0"
   },

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ui",
-  "version": "1.0.0-beta.24",
+  "version": "1.0.0-beta.30",
   "description": "Customisable components and primitives based on design tokens",
   "homepage": "https://react-ui.dev",
   "source": "index.js",

--- a/packages/react-ui/rollup.config.js
+++ b/packages/react-ui/rollup.config.js
@@ -2,6 +2,7 @@ import babel from 'rollup-plugin-babel'
 import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
 import external from 'rollup-plugin-peer-deps-external'
+import json from 'rollup-plugin-json'
 
 import pkg from './package.json'
 
@@ -14,7 +15,8 @@ const plugins = [
     presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react'],
     exclude: 'node_modules/**'
   }),
-  commonjs()
+  commonjs(),
+  json()
 ]
 
 export default [
@@ -29,13 +31,13 @@ export default [
       {
         dir: 'dist/themes/',
         format: 'cjs',
-        exports: 'named',
+        exports: 'named'
       },
       {
         dir: 'themes',
         format: 'cjs',
-        exports: 'named',
-      },
+        exports: 'named'
+      }
     ],
     plugins
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12910,6 +12910,13 @@ rollup-plugin-commonjs@^10.1.0:
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-4.0.0.tgz#a18da0a4b30bf5ca1ee76ddb1422afbb84ae2b9e"
+  integrity sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==
+  dependencies:
+    rollup-pluginutils "^2.5.0"
+
 rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
@@ -12926,7 +12933,7 @@ rollup-plugin-peer-deps-external@^2.2.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.2.tgz#506cef67fb68f41cca3ec08ca6ff7936b190f568"
   integrity sha512-XcHH4UW9exRTAf73d8rk2dw2UgF//cWbilhRI4Ni/n+t0zA1eBtohKyJROn0fxa4/+WZ5R3onAyIDiwRQL+59A==
 
-rollup-pluginutils@^2.8.1:
+rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.8.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==


### PR DESCRIPTION
The staging deployment was using a version from npm instead of the dev version from yarn workspaces. Needed to change a few things from the zeit dashboard + tiny changes to the build script for docs.

+ bonus: Added version in the docs header 