### PR TITLE
fix: tooltip image on /components page.

### DIFF
--- a/packages/docs/src/pages/components/index.js
+++ b/packages/docs/src/pages/components/index.js
@@ -78,7 +78,7 @@ const Documentation = () => {
               borderColor: 'grays.200'
             }}
           >
-            <Avatar size="small" src="https://react-ui.dev/favicon.png" />
+            <Avatar size="small" src="https://github.com/sameen-shi.png" />
             <Element
               as="div"
               css={{
@@ -393,7 +393,7 @@ const Documentation = () => {
         </ComponentCard>
         <ComponentCard name="Tooltip">
           <Tooltip label="Hey, this is the favicon!" INTERNAL_DEBUG_MODE>
-            <Avatar size="small" src="https://react-ui.dev/favicon.png" />
+            <Avatar size="small" src="https://github.com/sameen-shi.png" />
           </Tooltip>
         </ComponentCard>
       </Section>


### PR DESCRIPTION
Fix for Broken Images: #66 

- [x] Tooltip - image added (source: https://github.com/sameen-shi.png)

- [x] Theme Provider - image added (source: https://github.com/sameen-shi.png)

`favicon.png was not included in ./docs/public`.

Resolved. Let me know if any required changes need to be added.

Thanks