### PR TITLE
Sync reach component versions

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@ds-tools/theme.css": "0.0.1",
-    "@reach/accordion": "^0.10.0",
+    "@reach/accordion": "^0.10.1",
     "@reach/router": "^1.3.1",
     "@reach/visually-hidden": "^0.10.1",
     "@styled-system/theme-get": "^5.1.1",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -20,21 +20,21 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@reach/auto-id": "^0.7.0",
-    "@reach/dialog": "^0.10.0",
+    "@reach/auto-id": "^0.10.1",
+    "@reach/dialog": "^0.10.1",
     "@reach/tooltip": "^0.10.1",
     "@reach/menu-button": "^0.10.1",
     "deepmerge": "4.0.0",
     "dlv": "^1.1.3",
     "emotion-theming": "^10.0.27",
-    "facepaint": "^1.2.1",
-    "prop-types": "^15.7.2"
+    "facepaint": "^1.2.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
     "@ds-tools/storybook": "0.0.1",
     "bundlesize2": "^0.0.24",
+    "prop-types": "^15.7.2",
     "rollup": "^1.27.8",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -27,6 +27,7 @@
     "deepmerge": "4.0.0",
     "dlv": "^1.1.3",
     "emotion-theming": "^10.0.27",
+    "prop-types": "^15.7.2",
     "facepaint": "^1.2.1"
   },
   "devDependencies": {
@@ -34,7 +35,6 @@
     "@babel/preset-react": "^7.7.4",
     "@ds-tools/storybook": "0.0.1",
     "bundlesize2": "^0.0.24",
-    "prop-types": "^15.7.2",
     "rollup": "^1.27.8",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,7 +1391,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@reach/accordion@^0.10.0":
+"@reach/accordion@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@reach/accordion/-/accordion-0.10.1.tgz#bf99eae9b343a33ac5df020b9c56da7e907021b2"
   integrity sha512-hhiLp08dhce4OsEtoLhXsqtIqZi6W4us2wHsuvQUgf6w7h1UIGtAMXl2/k4lzynwBtYSIY4fuqktzGgFGVwa4w==
@@ -1422,17 +1422,17 @@
     "@reach/utils" "^0.10.1"
     tslib "^1.11.1"
 
-"@reach/dialog@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.10.0.tgz#85d4c9d7dea34a2ecfcd4c704f46ed86359d8bdf"
-  integrity sha512-RqO+J0R6TNdxKuTKwRzB7lBs5RjG/X8m4owLgZuunFRUSX1kWcXp7j8oCHJWwkDTwerrt6Ob96xCeUsalIUALQ==
+"@reach/dialog@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.10.1.tgz#c4056a0eef402a46ce94017415dd3c947855f73b"
+  integrity sha512-IPzuBH6dKeYPDFoybSntiDrO0r7dByOxClh/oSjmpOknspTLUPUjef73csA7/Ma9u7+C0wyEILXljYZXM3LfeQ==
   dependencies:
-    "@reach/portal" "^0.10.0"
-    "@reach/utils" "^0.10.0"
+    "@reach/portal" "^0.10.1"
+    "@reach/utils" "^0.10.1"
     prop-types "^15.7.2"
-    react-focus-lock "^2.2.1"
-    react-remove-scroll "^2.2.0"
-    tslib "^1.10.0"
+    react-focus-lock "^2.3.1"
+    react-remove-scroll "^2.3.0"
+    tslib "^1.11.1"
 
 "@reach/menu-button@^0.10.1":
   version "0.10.1"
@@ -1488,7 +1488,7 @@
     "@reach/utils" "^0.7.4"
     tabbable "^4.0.0"
 
-"@reach/portal@^0.10.0", "@reach/portal@^0.10.1":
+"@reach/portal@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.10.1.tgz#07329846ef45bb1af362d4470dd137087b39da68"
   integrity sha512-axap4IxA0xgsxluqyeyVuGZrStqaZ81iyiHmXFn+D+bjDNdd29colHm5GEB5mjGnkqktcXWyx5DQ+aRHIyGEkQ==
@@ -1542,7 +1542,7 @@
     prop-types "^15.7.2"
     tslib "^1.11.1"
 
-"@reach/utils@^0.10.0", "@reach/utils@^0.10.1":
+"@reach/utils@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.1.tgz#ee0283f81e161db4126a943b5c908a69f6a66d7e"
   integrity sha512-YzwZWVK+rSiUATNVtK7H2/ZkT/GhNKmkRjnj3hnVhSYLGxY9uQdfc+npetOqkh4hTAOXiErDa64ybVClR3h0TA==
@@ -6376,6 +6376,11 @@ focus-lock@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
   integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
+
+focus-lock@^0.6.7:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.8.tgz#61985fadfa92f02f2ee1d90bc738efaf7f3c9f46"
+  integrity sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -12059,13 +12064,25 @@ react-fast-compare@^2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-focus-lock@^2.1.0, react-focus-lock@^2.2.1:
+react-focus-lock@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
   integrity sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     focus-lock "^0.6.6"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.2"
+    use-callback-ref "^1.2.1"
+    use-sidecar "^1.0.1"
+
+react-focus-lock@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.3.1.tgz#9d5d85899773609c7eefa4fc54fff6a0f5f2fc47"
+  integrity sha512-j15cWLPzH0gOmRrUg01C09Peu8qbcdVqr6Bjyfxj80cNZmH+idk/bNBYEDSmkAtwkXI+xEYWSmHYqtaQhZ8iUQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.6.7"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.2"
     use-callback-ref "^1.2.1"
@@ -12148,7 +12165,7 @@ react-remove-scroll-bar@^2.1.0:
     react-style-singleton "^2.1.0"
     tslib "^1.0.0"
 
-react-remove-scroll@^2.2.0:
+react-remove-scroll@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.3.0.tgz#3af06fe2f7130500704b676cdef94452c08fe593"
   integrity sha512-UqVimLeAe+5EHXKfsca081hAkzg3WuDmoT9cayjBegd6UZVhlTEchleNp9J4TMGkb/ftLve7ARB5Wph+HJ7A5g==


### PR DESCRIPTION
By using the same version of reach ui components, we can make sure there is only one version of sub-dependencies as well which should lead to a slightly smaller bundlesize

update: lol that totally did not work. there is no difference in size :) 
but still useful 🤷 