### PR TITLE
fix: dark theme styling changed.

### DIFF
--- a/packages/docs/src/pages/components/index.js
+++ b/packages/docs/src/pages/components/index.js
@@ -61,7 +61,7 @@ const Documentation = () => {
               backgroundColor: 'grays.200'
             }}
           >
-            <Text variant="subtle" size={3}>
+            <Text variant="subtle" size={3} style={{ color: 'text.textColor' }}>
               Base Element
             </Text>
           </Element>
@@ -343,7 +343,7 @@ const Documentation = () => {
             <Element
               as="ul"
               css={{
-                backgroundColor: 'white',
+                backgroundColor: 'text.themeColor',
                 color: 'text.body',
                 border: '1px solid',
                 borderColor: 'grays.200',
@@ -422,7 +422,7 @@ const ComponentCard = ({ name, css = {}, ...props }) => {
           width: 'auto',
           height: '240px',
           ':hover': {
-            backgroundColor: 'grays.100'
+            backgroundColor: 'text.themeColor'
           },
           ...css
         }}

--- a/packages/react-ui/src/themes/dark.js
+++ b/packages/react-ui/src/themes/dark.js
@@ -155,6 +155,8 @@ tokens.sizes = { ...tokens.space }
 */
 
 tokens.colors.text = {
+  textColor: 'grays.800',
+  themeColor: 'grays.800',
   subtle: 'grays.500',
   body: 'grays.100',
   link: 'blues.400',

--- a/packages/react-ui/src/themes/light.js
+++ b/packages/react-ui/src/themes/light.js
@@ -139,6 +139,8 @@ tokens.sizes = { ...tokens.space }
 */
 
 tokens.colors.text = {
+  textColor: 'grays.800',
+  themeColor: 'grays.100',
   subtle: 'grays.700',
   body: 'grays.800',
   link: 'blues.500',


### PR DESCRIPTION
Fix for #72 

- [x] Paragraph

- [x] Menu

- [x] Element

- [x] Heading

> Required styling has been changed in the Dark theme.     

Let me know if there are any more changes that need to be done.

Thanks