### PR TITLE
Test: remove margin 0

### DIFF
--- a/packages/react-ui/src/components/checkbox/checkbox.styles.js
+++ b/packages/react-ui/src/components/checkbox/checkbox.styles.js
@@ -1,1 +1,5 @@
-
+export const styles = {
+  Checkbox: {
+    margin: 0
+  }
+}

--- a/packages/react-ui/src/components/checkbox/index.js
+++ b/packages/react-ui/src/components/checkbox/index.js
@@ -4,6 +4,7 @@ import { useId } from '@reach/auto-id'
 import { Text } from '../text'
 import { Stack } from '../stack'
 import { Element } from '../../primitives'
+import { styles } from './checkbox.styles'
 import { merge } from '../../utils'
 
 export const Checkbox = ({ id, label, css, ...props }) => {

--- a/packages/react-ui/src/components/checkbox/index.js
+++ b/packages/react-ui/src/components/checkbox/index.js
@@ -6,7 +6,7 @@ import { Stack } from '../stack'
 import { Element } from '../../primitives'
 import { merge } from '../../utils'
 
-export const Checkbox = ({ id, label, ...props }) => {
+export const Checkbox = ({ id, label, css, ...props }) => {
   const inputId = useId(id)
   return (
     <Stack align="center" gap={2}>
@@ -16,6 +16,7 @@ export const Checkbox = ({ id, label, ...props }) => {
         component="Checkbox"
         id={inputId}
         {...props}
+        css={merge(styles.Checkbox, css)}
       />
       <Text as="label" htmlFor={inputId}>
         {label}

--- a/packages/react-ui/src/primitives/element.js
+++ b/packages/react-ui/src/primitives/element.js
@@ -93,7 +93,7 @@ function Element(
   }
 
   // reset: by default components should have no margin
-  const margins = { margin: 0 }
+  const margins = {}
   // because of the above reset, we have to manually handle overrides
   marginProps.map(m => {
     if (typeof themeStyles[m] !== 'undefined') margins[m] = themeStyles[m]


### PR DESCRIPTION
Removing a strong {margin: 0} from styles so that it doesn't override user specified fields because of incorrect order

This might help with https://github.com/siddharthkp/react-ui/pull/51

Visual tests helped to find out there was only 1 component affected - checkbox. Added margin:0 in base styles for that

