### PR TITLE
Added prod & dev build scripts to reduces bundle size in production

### DIFF
--- a/packages/react-ui/main.js
+++ b/packages/react-ui/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./dist/react-ui.min.js');
+} else {
+  module.exports = require('./dist/react-ui.js');
+}

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -4,7 +4,7 @@
   "description": "Customisable components and primitives based on design tokens",
   "homepage": "https://react-ui.dev",
   "source": "index.js",
-  "main": "dist/index.js",
+  "main": "main.js",
   "files": [
     "dist",
     "themes"
@@ -37,13 +37,15 @@
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
     "@ds-tools/storybook": "0.0.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "bundlesize2": "^0.0.24",
     "rollup": "^1.27.8",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-peer-deps-external": "^2.2.0"
+    "rollup-plugin-peer-deps-external": "^2.2.0",
+    "rollup-plugin-terser": "^5.3.0"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/react-ui/rollup.config.js
+++ b/packages/react-ui/rollup.config.js
@@ -3,42 +3,43 @@ import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
 import external from 'rollup-plugin-peer-deps-external'
 import json from 'rollup-plugin-json'
+import { terser } from 'rollup-plugin-terser'
+import reactRemovePropType from 'babel-plugin-transform-react-remove-prop-types'
 
 import pkg from './package.json'
 
-const plugins = [
-  external({
-    includeDependencies: true
-  }),
-  resolve(),
-  babel({
-    presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react'],
-    exclude: 'node_modules/**'
-  }),
-  commonjs(),
-  json()
-]
+const getPlugins = (isProd) => {
+  return [
+    external({ includeDependencies: true }),
+    resolve(),
+    babel({
+      presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react'],
+      plugins: [isProd && [reactRemovePropType, { mode: 'wrap' }]].filter(Boolean), // using wrap to include propTypes only when process.env.NODE_ENV !== "production" 
+      exclude: 'node_modules/**'
+    }),
+    commonjs(),
+    json(),
+    isProd && terser()
+  ]
+}
+
+const cjs = [{
+  input: pkg.source,
+  output: { file: `dist/${pkg.name}.js`, format: 'cjs', sourcemap: true, esModule: false },
+  plugins: getPlugins(false) // dev env plugins
+}, {
+  input: pkg.source,
+  output: { file: `dist/${pkg.name}.min.js`, format: 'cjs', sourcemap: true },
+  plugins: getPlugins(true) // prod env plugins
+}];
 
 export default [
-  {
-    input: pkg.source,
-    output: [{ file: pkg.main, format: 'cjs' }],
-    plugins
-  },
-  {
+  ...cjs, {
     input: ['src/themes/base.js', 'src/themes/light.js', 'src/themes/dark.js'],
     output: [
-      {
-        dir: 'dist/themes/',
-        format: 'cjs',
-        exports: 'named'
-      },
-      {
-        dir: 'themes',
-        format: 'cjs',
-        exports: 'named'
-      }
+      { dir: 'dist/themes/', format: 'cjs', exports: 'named' },
+      { dir: 'themes', format: 'cjs', exports: 'named' }
     ],
-    plugins
+    plugins: getPlugins(true)
   }
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,7 +4209,7 @@ babel-plugin-transform-property-literals@^6.9.4:
   dependencies:
     esutils "^2.0.2"
 
-babel-plugin-transform-react-remove-prop-types@0.4.24:
+babel-plugin-transform-react-remove-prop-types@0.4.24, babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
@@ -14961,7 +14961,18 @@ rollup-plugin-peer-deps-external@^2.2.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.2.tgz#506cef67fb68f41cca3ec08ca6ff7936b190f568"
   integrity sha512-XcHH4UW9exRTAf73d8rk2dw2UgF//cWbilhRI4Ni/n+t0zA1eBtohKyJROn0fxa4/+WZ5R3onAyIDiwRQL+59A==
 
-rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.8.1:
+rollup-plugin-terser@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz#9c0dd33d5771df9630cd027d6a2559187f65885e"
+  integrity sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    jest-worker "^24.9.0"
+    rollup-pluginutils "^2.8.2"
+    serialize-javascript "^2.1.2"
+    terser "^4.6.2"
+
+rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -16276,6 +16287,15 @@ terser@^4.1.2, terser@^4.4.3, terser@^4.6.3:
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.6.tgz#da2382e6cafbdf86205e82fb9a115bd664d54863"
   integrity sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.6.2:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"
+  integrity sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
- Loading separate file based on NODE_ENV
- Added terser plugin for production
- Removing PropTypes from production by using [react-remove-prop-types](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types) Babel plugin